### PR TITLE
updates makefile with simple table schema and makefile

### DIFF
--- a/ci/db/setup.sh
+++ b/ci/db/setup.sh
@@ -3,6 +3,10 @@
 # flag to fail bash script if error occurs
 set -e
 
+# grabs PG_DEV_PASSWORD from env, if it doesn't exist use 'password' string
+PG_DEV_PASSWORD=${PG_DEV_PASSWORD:-'password'}
+PG_SCHEMA_FILE=${PG_SCHEMA_FILE:-'db/schema.sql'}
+
 # pulls latest postgres image
 docker pull postgres:12.1
 
@@ -23,3 +27,7 @@ else
     brew install postgres
     brew install pgcli
 fi
+
+# deploy schema to container
+export PGPASSWORD=${PG_DEV_PASSWORD} \
+    && psql -h localhost -p 5432 -U postgres -f ${PG_SCHEMA_FILE}

--- a/ci/db/setup.sh
+++ b/ci/db/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# flag to fail installation if
+set -e
+
+# pulls latest postgres image
+docker pull postgres:12.1
+
+docker run -d \
+    --name betany-db \
+    -e POSTGRES_PASSWORD=password \
+    -p 5432:5432 \
+    postgres:12.1
+
+echo 'waiting for postgres DB to complete setup...'
+sleep 5
+
+# checks to see if pgcli is installed. If not, brew install it.
+if type pgcli >/dev/null 2>&1; then
+    echo 'pgcli already installed...'
+else
+    echo 'installing pgcli...'
+    brew install pgcli
+fi

--- a/ci/db/setup.sh
+++ b/ci/db/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# flag to fail installation if
+# flag to fail bash script if error occurs
 set -e
 
 # pulls latest postgres image

--- a/ci/db/setup.sh
+++ b/ci/db/setup.sh
@@ -20,5 +20,6 @@ if type pgcli >/dev/null 2>&1; then
     echo 'pgcli already installed...'
 else
     echo 'installing pgcli...'
+    brew install postgres
     brew install pgcli
 fi

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,6 @@
+-- bets table
+create table bets (
+    id bigserial primary key,
+    name text not null,
+    description text
+);

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
-PHONY: db connect-db cleanup-db
+.PHONY: db connect-db cleanup-db
 PG_DEV_PASSWORD=password
 
 db:
 	echo 'setting up local DB'
-	sh ci/db/setup.sh
+	export PG_DEV_PASSWORD=$(PG_DEV_PASSWORD) && sh ci/db/setup.sh
 
 connect-db:
 	export PGPASSWORD=$(PG_DEV_PASSWORD) && pgcli -h localhost -p 5432 -U postgres

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-PHONY: db
+PHONY: db connect-db cleanup-db
 PG_DEV_PASSWORD=password
 
 db:

--- a/makefile
+++ b/makefile
@@ -1,0 +1,13 @@
+PHONY: db
+PG_DEV_PASSWORD=password
+
+db:
+	echo 'setting up local DB'
+	sh ci/db/setup.sh
+
+connect-db:
+	export PGPASSWORD=$(PG_DEV_PASSWORD) && pgcli -h localhost -p 5432 -U postgres
+
+cleanup-db:
+	docker kill betany-db
+	docker rm betany-db

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+# BetAny
+
+Requirements:
+* Docker
+


### PR DESCRIPTION
## what is this?
Adds a makefile that handles the setup and clean up of a postgres DB used for local development. Includes a simple example schema as well.

```bash
# setups up the database and installs the pgcli tool using homebrew. Deploys the example schema.
make db 

# connect to the DB using pgcli
make connect-db 

# kills and removes the postgres container (and any data stored).
make cleanup-db
```

This is only really useful for local development and anything we would want to perform a real deployment with (e.g. the cloud) we would need to spend some time working on.